### PR TITLE
Pseudo-corpus changes

### DIFF
--- a/src/Editor/Config.ts
+++ b/src/Editor/Config.ts
@@ -99,6 +99,7 @@ const anonymization: Taxonomy = [
       {label: 'initials', desc: ''},
       {label: 'middlename', desc: ''},
       {label: 'surname', desc: ''},
+      {label: 'nickname', desc: ''},
     ],
   },
   {
@@ -107,7 +108,7 @@ const anonymization: Taxonomy = [
       {label: 'foreign', desc: ''},
       {label: 'area', desc: ''},
       {label: 'city', desc: 'city including villages'},
-      {label: 'country', desc: 'except Sweden'},
+      {label: 'country', desc: ''},
       {label: 'geo', desc: 'forest, lake, mountain, etc'},
       {label: 'place', desc: ''},
       {label: 'region', desc: ''},
@@ -120,6 +121,7 @@ const anonymization: Taxonomy = [
     entries: [
       {label: 'school', desc: ''},
       {label: 'work', desc: ''},
+      {label: 'public_authority', desc: 'Skatteverket, Socialtänsten, etc.'},
       {label: 'other_institution', desc: ''},
     ],
   },
@@ -142,6 +144,9 @@ const anonymization: Taxonomy = [
       {label: 'month_digit', desc: ''},
       {label: 'month_word', desc: ''},
       {label: 'year', desc: ''},
+      {label: 'past_timepoint', desc: 'yesterday, Friday'},
+      {label: 'future_timepoint', desc: 'tomorrow, Wednesday'},
+      {label: 'time_span', desc: 'two weeks, five months'},
     ],
   },
   {
@@ -155,6 +160,10 @@ const anonymization: Taxonomy = [
       {label: 'phone_nr', desc: ''},
       {label: 'personid_nr', desc: ''},
       {label: 'url', desc: ''},
+      {label: 'username', desc: 'usernames and @names from online contexts'},
+      {label: 'pet_type', desc: 'pet breed or species, for names use name_xyz'},
+      {label: 'language', desc: '(foreign) language spoken'},
+      {label: 'hobby', desc: 'routine and relatively unique activity'},
     ],
   },
   {

--- a/src/Editor/Config.ts
+++ b/src/Editor/Config.ts
@@ -163,6 +163,7 @@ const anonymization: Taxonomy = [
       {label: 'username', desc: 'usernames and @names from online contexts'},
       {label: 'pet_type', desc: 'pet breed or species, for names use name_xyz'},
       {label: 'language', desc: '(foreign) language spoken'},
+      {label: 'ethnicity', desc: ''},
       {label: 'hobby', desc: 'routine and relatively unique activity'},
     ],
   },

--- a/src/Editor/Config.ts
+++ b/src/Editor/Config.ts
@@ -166,6 +166,8 @@ const anonymization: Taxonomy = [
       {label: 'ethnicity', desc: ''},
       {label: 'currency', desc: ''},
       {label: 'hobby', desc: 'routine and relatively unique activity'},
+      {label: 'crime', desc: 'a crime perpetrated by or against the person in question'},
+      {label: 'health_condition', desc: 'an illness, injury, or any other condition influencing health'},
     ],
   },
   {

--- a/src/Editor/Config.ts
+++ b/src/Editor/Config.ts
@@ -164,6 +164,7 @@ const anonymization: Taxonomy = [
       {label: 'pet_type', desc: 'pet breed or species, for names use name_xyz'},
       {label: 'language', desc: '(foreign) language spoken'},
       {label: 'ethnicity', desc: ''},
+      {label: 'currency', desc: ''},
       {label: 'hobby', desc: 'routine and relatively unique activity'},
     ],
   },


### PR DESCRIPTION
As discussed with Arild, these are our proposed changes to the pseudo/anonymization taxonomy for the sake of annotating new data using SVALA. Changes include:

- Adding _nickname, public_authority, past_timepoint, future_timepoint, time_span, username, pet_type, language, hobby, ethnicity, currency, crime, health_condition_
- Removing constraints from _country_